### PR TITLE
refactor transpose

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -9,14 +9,6 @@
 #include "core/providers/webgpu/webgpu_utils.h"
 #include "core/providers/webgpu/math/matmul.h"
 
-namespace {
-
-inline uint32_t ceil_div(int64_t numerator, int32_t denominator) {
-  return static_cast<uint32_t>((numerator + denominator - 1) / denominator);
-}
-
-}  // namespace
-
 namespace onnxruntime {
 namespace webgpu {
 

--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -27,37 +27,9 @@ Status TransposeKernel(ComputeContext& context, const Tensor* kernel, const Tens
   for (size_t i = 0; i < rank; ++i) {
     transposed_kernel_shape_vector[i] = kernel_shape[perm[i]];
   }
-  uint32_t output_size = onnxruntime::narrow<uint32_t>(kernel_shape.Size());
-
-  uint32_t dispatch_x = ceil_div(output_size, 64);
-  uint32_t dispatch_y = 1;
-  uint32_t dispatch_z = 1;
-
-  // This temporary workaround addresses a significant performance bottleneck
-  // (~12x slower) for the shape (3, 3, 2560, 1280) due to an issue with Intel's
-  // GPU drivers. We manually normalize the dispatch group size to restore
-  // performance.
-  //
-  // TODO: Revert this change once the driver issue is fixed.
-  if (context.AdapterInfo().vendor == std::string_view{"intel"}) {
-    ORT_ENFORCE(rank == static_cast<size_t>(4), "Input tensor must have rank 4.");
-    dispatch_x = ceil_div(transposed_kernel_shape_vector[0] * transposed_kernel_shape_vector[1], 2);
-    dispatch_y = ceil_div(transposed_kernel_shape_vector[2], 4);
-    dispatch_z = ceil_div(transposed_kernel_shape_vector[3], 8);
-  }
-
   TensorShape transposed_kernel_shape(transposed_kernel_shape_vector);
   *transposed_kernel = context.CreateGPUTensor(kernel->DataType(), transposed_kernel_shape);
-  bool use_shared = false;
-  TransposeProgram program{perm, use_shared};
-  program
-      .CacheHint(absl::StrJoin(perm, "-"))
-      .AddInput({kernel, ProgramTensorMetadataDependency::TypeAndRank, kernel_shape, 1})
-      .AddOutput({transposed_kernel, ProgramTensorMetadataDependency::TypeAndRank})
-      .AddUniformVariable({output_size})
-      .SetWorkgroupSize(64)
-      .SetDispatchGroupSize(dispatch_x, dispatch_y, dispatch_z);
-  return context.RunProgram(program);
+  return Transpose::DoTranspose(context, perm, *kernel, *transposed_kernel, &kernel_shape, &transposed_kernel_shape);
 }
 
 template <bool is_channels_last, bool is_fused>

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -160,7 +160,7 @@ Status Transpose::DoTranspose(onnxruntime::webgpu::ComputeContext& context,
   if (use_shared) {
     program.SetWorkgroupSize(TILE_SIZE, TILE_SIZE, 1);
     program.SetDispatchGroupSize(static_cast<uint32_t>((new_output_shape[1] + TILE_SIZE - 1) / TILE_SIZE),
-                                  static_cast<uint32_t>(((new_output_shape[0] + TILE_SIZE - 1) / TILE_SIZE)));
+                                 static_cast<uint32_t>(((new_output_shape[0] + TILE_SIZE - 1) / TILE_SIZE)));
   } else {
     program.SetWorkgroupSize(WORKGROUP_SIZE);
 

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -102,15 +102,22 @@ Status TransposeProgram::GenerateShaderCode(ShaderHelper& shader) const {
 
 Status Transpose::DoTranspose(onnxruntime::webgpu::ComputeContext& context,
                               gsl::span<const size_t> permutations,
-                              const Tensor& input, Tensor& output) {
-  const auto& input_shape = input.Shape();
+                              const Tensor& input, Tensor& output, const TensorShape* input_shape_ptr, TensorShape* output_shape_ptr) {
+  const auto& input_shape = input_shape_ptr ? *input_shape_ptr : input.Shape();
   const auto& input_dims = input_shape.GetDims();
   int32_t rank = static_cast<int32_t>(input_shape.NumDimensions());
 
   TensorShapeVector output_dims(rank);
 
-  for (int32_t i = 0; i < rank; i++) {
-    output_dims[i] = input_dims[permutations[i]];
+  if (output_shape_ptr) {
+    auto dims = output_shape_ptr->GetDims();
+    for (size_t i = 0; i < rank; ++i) {
+      output_dims[i] = dims[i];
+    }
+  } else {
+    for (int32_t i = 0; i < rank; i++) {
+      output_dims[i] = input_dims[permutations[i]];
+    }
   }
 
   TensorShapeVector new_shape{};

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.cc
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.cc
@@ -153,14 +153,14 @@ Status Transpose::DoTranspose(onnxruntime::webgpu::ComputeContext& context,
       .CacheHint(absl::StrJoin(permutations, "-"))
       .AddInputs({{&input, ProgramTensorMetadataDependency::TypeAndRank, new_input_shape, 1}})
       .AddOutputs({{&output, ProgramTensorMetadataDependency::None, new_output_shape, 1}})
-      .SetDispatchGroupSize(static_cast<uint32_t>((new_output_shape[1] + TILE_SIZE - 1) / TILE_SIZE),
-                            static_cast<uint32_t>(((new_output_shape[0] + TILE_SIZE - 1) / TILE_SIZE)))
       .AddUniformVariables({
           {static_cast<uint32_t>(output_size)},
       });
 
   if (use_shared) {
     program.SetWorkgroupSize(TILE_SIZE, TILE_SIZE, 1);
+    program.SetDispatchGroupSize(static_cast<uint32_t>((new_output_shape[1] + TILE_SIZE - 1) / TILE_SIZE),
+                                  static_cast<uint32_t>(((new_output_shape[0] + TILE_SIZE - 1) / TILE_SIZE)));
   } else {
     program.SetWorkgroupSize(WORKGROUP_SIZE);
 

--- a/onnxruntime/core/providers/webgpu/tensor/transpose.h
+++ b/onnxruntime/core/providers/webgpu/tensor/transpose.h
@@ -16,7 +16,7 @@ class Transpose final : public WebGpuKernel, public TransposeBase {
   Transpose(const OpKernelInfo& info) : WebGpuKernel{info}, TransposeBase{info} {
   }
   Status ComputeInternal(ComputeContext& context) const override;
-  static Status DoTranspose(onnxruntime::webgpu::ComputeContext& context, gsl::span<const size_t> permutations, const Tensor& input, Tensor& output);
+  static Status DoTranspose(onnxruntime::webgpu::ComputeContext& context, gsl::span<const size_t> permutations, const Tensor& input, Tensor& output, const TensorShape* input_shape_ptr = nullptr, TensorShape* output_shape_ptr = nullptr);
 
   constexpr static uint32_t TILE_SIZE = 16;
 };


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
This PR try to refactor `TransposeKernel` with `Transpose::DoTranspose`.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
In some invocation of `TransposeKernel`, we may have some unsqueezed shape for input, so we will pass some arguments for`Transpose::DoTranspose` to avoid the reshape. 


