### PR TITLE
[webgpu] Optimize InstanceNormalization by removing redundant transpose

### DIFF
--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -935,17 +935,15 @@ std::unique_ptr<onnxruntime::IExternalDataLoader> WebGpuExecutionProvider::GetEx
 std::optional<bool> WebGpuExecutionProvider::ShouldConvertDataLayoutForOp(std::string_view node_domain,
                                                                           std::string_view node_op_type,
                                                                           DataLayout target_data_layout) const {
-  if (target_data_layout != DataLayout::NHWC) {
-    return std::nullopt;
-  }
-
   // NHWC for Resize operator is not implemented on kWebGpuExecutionProvider
   if (node_domain == kOnnxDomain && node_op_type == "Resize") {
-    return false;
+    if (target_data_layout != DataLayout::NHWC) {
+      return false;
+    }
   }
 
+  // Both NHWC and NCHW are supported for InstanceNormalization, so it don't need to convert layout for it.
   if (node_domain == kOnnxDomain && node_op_type == "InstanceNormalization") {
-    // WebGPU backend already support not nhwc format, it's not necessary to add convert layout.
     return false;
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -945,6 +945,7 @@ std::optional<bool> WebGpuExecutionProvider::ShouldConvertDataLayoutForOp(std::s
   }
 
   if (node_domain == kOnnxDomain && node_op_type == "InstanceNormalization") {
+    // WebGPU backend already support not nhwc format, it's not necessary to add convert layout.
     return false;
   }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -944,6 +944,10 @@ std::optional<bool> WebGpuExecutionProvider::ShouldConvertDataLayoutForOp(std::s
     return false;
   }
 
+  if (node_domain == kOnnxDomain && node_op_type == "InstanceNormalization") {
+    return false;
+  }
+
   return std::nullopt;
 }
 

--- a/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
+++ b/onnxruntime/core/providers/webgpu/webgpu_execution_provider.cc
@@ -937,14 +937,12 @@ std::optional<bool> WebGpuExecutionProvider::ShouldConvertDataLayoutForOp(std::s
                                                                           DataLayout target_data_layout) const {
   // NHWC for Resize operator is not implemented on kWebGpuExecutionProvider
   if (node_domain == kOnnxDomain && node_op_type == "Resize") {
-    if (target_data_layout != DataLayout::NHWC) {
-      return false;
-    }
+    return target_data_layout != DataLayout::NHWC;
   }
 
-  // Both NHWC and NCHW are supported for InstanceNormalization, so it don't need to convert layout for it.
+  // WebGPU perfer NCHW for InstanceNormalization due to a better performance
   if (node_domain == kOnnxDomain && node_op_type == "InstanceNormalization") {
-    return false;
+    return target_data_layout != DataLayout::NHWC;
   }
 
   return std::nullopt;


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR optimizes `InstanceNormalization` by removing redundant transpose.

Given the implementation of `InstanceNormalization` for `NCHW` is more effiencient, we don't need to add wrapper `Transpose` to make it run in `NHWC`, which helps use to elide redundant transpose and improve performance.

Testing on Lunar Lake shows about `~60%` performance improvement in `InstanceNormalization` operations.

#### `InstanceNormalization` OP benchmark
The input tensor shape: `(1,32,1048576)`
The scale tensor shape: `(32)`
The B tensor shape: `(32)`

| time cost (ms) | baseline | opt | diff |
| ---------------- | -------- | ---- | ---- |
| Lunar Lake | 82.6 | 34.2 | 58% |

#### Model benchmark
| time cost (ms) | baseline | opt | diff |
| ---------------- | -------- | ---- | ---- |
| sd-turbo-vae-decoder-fp16-demo | 2437.6 | 1835.9 | 25% |

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
Please see above


