### PR TITLE
[webgpu] support auto pad for im2col

### DIFF
--- a/onnxruntime/core/providers/webgpu/nn/conv.cc
+++ b/onnxruntime/core/providers/webgpu/nn/conv.cc
@@ -118,7 +118,6 @@ Status Conv<is_channels_last, is_fused>::ComputeInternal(ComputeContext& context
                                   is_channels_last,
                                   activation_.activation_kind_,
                                   kernel_shape,
-                                  conv_attrs_.auto_pad,
                                   onnxruntime::narrow<uint32_t>(conv_attrs_.group))) {
     return ApplyIm2ColMatMulProgram(context,
                                     is_channels_last,

--- a/onnxruntime/core/providers/webgpu/nn/im2col_matmul.cc
+++ b/onnxruntime/core/providers/webgpu/nn/im2col_matmul.cc
@@ -190,7 +190,6 @@ bool CanApplyIm2ColMatMulProgram(ComputeContext& context,
                                  const bool is_channels_last,
                                  const ActivationKind activation_kind,
                                  const TensorShape weight_shape,
-                                 const AutoPadType auto_pad,
                                  const uint32_t group) {
   if (!IsDeviceSupported(context)) {
     return false;
@@ -198,9 +197,8 @@ bool CanApplyIm2ColMatMulProgram(ComputeContext& context,
 
   // TODO: Support !is_channels_last
   // TODO: Support fuse
-  // TODO: Support auto pad
   // TODO: Support group conv
-  if (!is_channels_last || activation_kind != ActivationKind::None || auto_pad != AutoPadType::NOTSET || group != 1) {
+  if (!is_channels_last || activation_kind != ActivationKind::None || group != 1) {
     return false;
   }
 

--- a/onnxruntime/core/providers/webgpu/nn/im2col_matmul.h
+++ b/onnxruntime/core/providers/webgpu/nn/im2col_matmul.h
@@ -78,7 +78,6 @@ bool CanApplyIm2ColMatMulProgram(ComputeContext& context,
                                  const bool is_channels_last,
                                  const ActivationKind activation_kind,
                                  const TensorShape kernel_shape,
-                                 const AutoPadType auto_pad,
                                  const uint32_t group);
 
 Status ApplyIm2ColMatMulProgram(ComputeContext& context,

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -536,6 +536,47 @@ TEST(ConvTest, Conv2D_AutoPad2) {
   TestConvOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape, true);
 }
 
+
+TEST(ConvTest, Conv2D_Im2col_AutoPad) {
+  ConvOpAndTestAttributes attrs = {
+      "SAME_UPPER",           // auto_pad
+      vector<int64_t>{1, 1},  // dilations
+      1,                      // group
+      vector<int64_t>{3, 3},  // kernel_shape
+      {},                     // pads
+      vector<int64_t>{1, 1},  // strides
+      {}                      // excluded EPs
+  };
+
+  vector<float> X = vector<float>(25 * 4, 1.0f);
+  vector<int64_t> X_shape = {1, 4, 5, 5};
+  vector<float> W = {0.0f, 1.0f, 2.0f,
+                     3.0f, 4.0f, 5.0f,
+                     6.0f, 7.0f, 8.0f,
+                     0.0f, 1.0f, 2.0f,
+                     3.0f, 4.0f, 5.0f,
+                     6.0f, 7.0f, 8.0f,
+                     0.0f, 1.0f, 2.0f,
+                     3.0f, 4.0f, 5.0f,
+                     6.0f, 7.0f, 8.0f,
+                     0.0f, 1.0f, 2.0f,
+                     3.0f, 4.0f, 5.0f,
+                     6.0f, 7.0f, 8.0f};
+
+  vector<int64_t> W_shape = {1, 4, 3, 3};
+  vector<int64_t> Y_shape = {1, 1, 5, 5};
+  auto expected_vals = {24.0f * 4, 33.0f * 4, 33.0f * 4, 33.0f * 4, 20.0f * 4,
+                        27.0f * 4, 36.0f * 4, 36.0f * 4, 36.0f * 4, 21.0f * 4,
+                        27.0f * 4, 36.0f * 4, 36.0f * 4, 36.0f * 4, 21.0f * 4,
+                        27.0f * 4, 36.0f * 4, 36.0f * 4, 36.0f * 4, 21.0f * 4,
+                        12.0f * 4, 15.0f * 4, 15.0f * 4, 15.0f * 4, 8.0f * 4};
+
+  TestConvOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape);
+
+  // NNAPI/CoreML EP requires weight to be an initializer
+  TestConvOp(attrs, {X, W}, {X_shape, W_shape}, expected_vals, Y_shape, true);
+}
+
 TEST(ConvTest, Conv2D_MatMul_SplitK_No_Bias) {
   ConvOpAndTestAttributes attrs = {
       "",                           // auto_pad

--- a/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
+++ b/onnxruntime/test/providers/cpu/nn/conv_op_test.cc
@@ -537,7 +537,7 @@ TEST(ConvTest, Conv2D_AutoPad2) {
 }
 
 
-TEST(ConvTest, Conv2D_Im2col_AutoPad) {
+TEST(ConvTest, Conv2D_AutoPad3) {
   ConvOpAndTestAttributes attrs = {
       "SAME_UPPER",           // auto_pad
       vector<int64_t>{1, 1},  // dilations


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->

This PR addressed the TODO about auto_pad for `im2col-matmul`, because the auto_pad attribute was used for computing the padding for the Conv2d before launching the kernel, so we don't need to do extra work to support it in the logic of the new `im2col-matmul` kernel.


### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


